### PR TITLE
Add async View/Json/RedirectResult

### DIFF
--- a/src/ufront/web/result/AsyncJsonResult.hx
+++ b/src/ufront/web/result/AsyncJsonResult.hx
@@ -1,0 +1,26 @@
+package ufront.web.result;
+import ufront.web.context.ActionContext;
+import ufront.web.result.JsonResult;
+
+using tink.CoreApi;
+/**
+ * ...
+ * @author Kevin
+ */
+class AsyncJsonResult<T> extends JsonResult<T>
+{
+	private var futureContent:Future<T>;
+	
+	public function new(futureContent:Future<T>) {
+		this.futureContent = futureContent;
+		super(null);
+	}
+	
+	override function executeResult(actionContext:ActionContext) {
+		return futureContent.flatMap(function(content) {
+			this.content = content;
+			return writeContentToResponse(actionContext);
+		});
+	}
+	
+}

--- a/src/ufront/web/result/AsyncRedirectResult.hx
+++ b/src/ufront/web/result/AsyncRedirectResult.hx
@@ -1,0 +1,26 @@
+package ufront.web.result;
+
+import ufront.web.context.ActionContext;
+import ufront.web.result.RedirectResult;
+
+using tink.CoreApi;
+/**
+ * ...
+ * @author Kevin
+ */
+class AsyncRedirectResult extends RedirectResult
+{
+	private var futureUrl:Future<String>;
+	
+	public function new(futureUrl:Future<String>, ?permanentRedirect=false) {
+		super("", permanentRedirect);
+		this.futureUrl = futureUrl;
+	}
+	
+	override function executeResult(actionContext:ActionContext) {
+		return futureUrl.flatMap(function(url) {
+			this.url = url;
+			return redirect(actionContext);
+		});
+	}
+}

--- a/src/ufront/web/result/AsyncViewResult.hx
+++ b/src/ufront/web/result/AsyncViewResult.hx
@@ -20,8 +20,7 @@ class AsyncViewResult extends ViewResult
 		super(null, viewPath, templatingEngine);
 	}
 	
-	override function executeResult(actionContext:ActionContext) 
-	{
+	override function executeResult(actionContext:ActionContext) {
 		return asyncData.flatMap(function(data)
 		{
 			this.data = data;

--- a/src/ufront/web/result/AsyncViewResult.hx
+++ b/src/ufront/web/result/AsyncViewResult.hx
@@ -13,15 +13,15 @@ using tink.CoreApi;
  */
 class AsyncViewResult extends ViewResult
 {
-	private var asyncData:Future<TemplateData>;
+	private var futureData:Future<TemplateData>;
 	
-	public function new(?asyncData:Future<TemplateData>, ?viewPath:String, ?templatingEngine:TemplatingEngine) {
-		this.asyncData = asyncData;
+	public function new(?futureData:Future<TemplateData>, ?viewPath:String, ?templatingEngine:TemplatingEngine) {
+		this.futureData = futureData;
 		super(null, viewPath, templatingEngine);
 	}
 	
 	override function executeResult(actionContext:ActionContext) {
-		return asyncData.flatMap(function(data)
+		return futureData.flatMap(function(data)
 		{
 			this.data = data;
 			return internalExecuteResult(actionContext);

--- a/src/ufront/web/result/AsyncViewResult.hx
+++ b/src/ufront/web/result/AsyncViewResult.hx
@@ -15,8 +15,7 @@ class AsyncViewResult extends ViewResult
 {
 	private var asyncData:Future<TemplateData>;
 	
-	public function new(?asyncData:Future<TemplateData>, ?viewPath:String, ?templatingEngine:TemplatingEngine) 
-	{
+	public function new(?asyncData:Future<TemplateData>, ?viewPath:String, ?templatingEngine:TemplatingEngine) {
 		this.asyncData = asyncData;
 		super(null, viewPath, templatingEngine);
 	}

--- a/src/ufront/web/result/AsyncViewResult.hx
+++ b/src/ufront/web/result/AsyncViewResult.hx
@@ -1,0 +1,32 @@
+package ufront.web.result;
+
+import ufront.view.TemplateData;
+import ufront.view.TemplatingEngines.TemplatingEngine;
+import ufront.web.context.ActionContext;
+import ufront.web.result.ViewResult;
+
+using tink.CoreApi;
+
+/**
+ * ...
+ * @author Kevin
+ */
+class AsyncViewResult extends ViewResult
+{
+	private var asyncData:Future<TemplateData>;
+	
+	public function new(?asyncData:Future<TemplateData>, ?viewPath:String, ?templatingEngine:TemplatingEngine) 
+	{
+		this.asyncData = asyncData;
+		super(null, viewPath, templatingEngine);
+	}
+	
+	override function executeResult(actionContext:ActionContext) 
+	{
+		return asyncData.flatMap(function(data)
+		{
+			this.data = data;
+			return internalExecuteResult(actionContext);
+		});
+	}
+}

--- a/src/ufront/web/result/JsonResult.hx
+++ b/src/ufront/web/result/JsonResult.hx
@@ -16,8 +16,11 @@ class JsonResult<T> extends ActionResult
 	}
 
 	override function executeResult( actionContext:ActionContext ) {
+		return writeContentToResponse(actionContext);
+	}
+	
+	private function writeContentToResponse(actionContext:ActionContext) {
 		NullArgument.throwIfNull(actionContext);
-
 		actionContext.httpContext.response.contentType = "application/json";
 		var serialized = Json.stringify( content );
 		actionContext.httpContext.response.write( serialized );

--- a/src/ufront/web/result/RedirectResult.hx
+++ b/src/ufront/web/result/RedirectResult.hx
@@ -20,6 +20,10 @@ class RedirectResult extends ActionResult
 	}
 
 	override function executeResult( actionContext:ActionContext ) {
+		return redirect(actionContext);
+	}
+	
+	private function redirect(actionContext:ActionContext) {
 		// Clear content and headers, but not cookies
 		actionContext.httpContext.response.clearContent();
 		actionContext.httpContext.response.clearHeaders();

--- a/src/ufront/web/result/ViewResult.hx
+++ b/src/ufront/web/result/ViewResult.hx
@@ -320,7 +320,10 @@ class ViewResult extends ActionResult {
 		- Write the final output to the `ufront.web.context.HttpResponse` with a `text/html` content type.
 	**/
 	override function executeResult( actionContext:ActionContext ) {
-
+		return internalExecuteResult(actionContext);
+	}
+	
+	private function internalExecuteResult( actionContext:ActionContext ) {
 		// Get the viewEngine
 		var viewEngine = try actionContext.httpContext.injector.getInstance( UFViewEngine ) catch (e:Dynamic) null;
 		if (viewEngine==null) return Sync.httpError( "Failed to find a UFViewEngine in ViewResult.executeResult(), please make sure that one is made available in your application's injector" );


### PR DESCRIPTION
Similar to ViewResult but accept a `Future<TemplateData>` instead of `TemplateData`. So this will work well with `AsyncApi`.

example:
```haxe
@:route(GET, "/profile/$id")
public function profile(id:Int):ActionResult
{
	var templateDataFuture = asyncAuthApi.getUser(id).map(function(user):Dynamic return {profile:user.profile});
	
	return new AsyncViewResult(templateDataFuture);
}
```

Note: we can't create closures calling `super.method`, so I moved the code to `internalExecuteResult()`