### PR TITLE
Normalize template path

### DIFF
--- a/src/ufront/view/UFViewEngine.hx
+++ b/src/ufront/view/UFViewEngine.hx
@@ -121,7 +121,7 @@ class UFViewEngine {
 				if ( tplEngines.length>0 ) {
 					var engine = tplEngines.shift();
 					if ( engine.extensions.has(ext) ) {
-						finalPath = path;
+						finalPath = haxe.io.Path.normalize(path);
 						getTemplateString( finalPath ).handle( function (result) switch result {
 							case Failure(err): tplStrReady.trigger( Failure(err) );
 							case Success(Some(tpl)):


### PR DESCRIPTION
Sometimes when the view path is specified as "../another/folder/file.html" in ExampleController, the view engine will try to find the file with the path "view/example/../another/folder/file.html". If "view/example" does not exist, it will fail. So we should normalize the path to "view/another/folder/file.html" first.
