### PR TITLE
Message Formatter

### DIFF
--- a/src/ufront/log/BasicMessageFormatter.hx
+++ b/src/ufront/log/BasicMessageFormatter.hx
@@ -1,0 +1,13 @@
+package ufront.log;
+
+class BasicMessageFormatter implements UFMessageFormatter {
+	var formatter:Message->String;
+	
+	public function new(formatter:Message->String) {
+		this.formatter = formatter;
+	}
+	
+	public function format(m:Message):String {
+		return formatter(m);
+	}
+}

--- a/src/ufront/log/UFMessageFormatter.hx
+++ b/src/ufront/log/UFMessageFormatter.hx
@@ -1,0 +1,5 @@
+package ufront.log;
+
+interface UFMessageFormatter {
+	function format(message:Message):String;
+}


### PR DESCRIPTION
Adding message formatter option for the Loggers.

But I am not sure how to make it configuration-friendly. Any ideas? 

Now I use it in a ugly way:

```haxe
for(l in ufrontApp.logHandlers) 
	if(Std.is(l, ServerConsoleLogger)) 
	{
		@:privateAccess cast(l, ServerConsoleLogger).messageFormatter = new BasicMessageFormatter(function(m)
		{
			var extras =
				if ( m.pos!=null && m.pos.customParams!=null ) ", "+m.pos.customParams.join(", ")
				else "";
				
			var type = Type.enumConstructor( m.type ).substr( 1 );
			switch(m.type)
			{
				case MError:
					return '$type: ${m.msg}$extras';
				default:
					return '$type: ${m.pos.className}.${m.pos.methodName}(${m.pos.lineNumber}): ${m.msg}$extras';
			}
		});
	}
```

