### PR TITLE
match StdTypes.Void as well

### DIFF
--- a/src/ufront/api/ApiMacros.hx
+++ b/src/ufront/api/ApiMacros.hx
@@ -180,7 +180,7 @@ class ApiMacros {
 					switch member.kind {
 						case FFun(fun):
 							var remotingCall = buildSyncFnBody(member.name,fun.args,member.pos);
-							var returnsVoid = fun.ret==null || fun.ret.match(TPath({name:"Void"}));
+							var returnsVoid = fun.ret==null || fun.ret.match(TPath({name:"Void"} | {sub:"Void"});
 							var pos = member.pos;
 							fun.expr =
  								if ( returnsVoid ) macro @:pos(pos) $remotingCall;


### PR DESCRIPTION
Sometimes there's `StdTypes.Void` instead of plain `Void` in the syntax, which in Haxe 3.3 leads to a compile-time error somewhere in the remoting code. 