### PR TITLE
Fixed issue where php would SegFault with large multipart file uploads (20MB+)

### DIFF
--- a/src/sys/ufront/web/context/HttpRequest.hx
+++ b/src/sys/ufront/web/context/HttpRequest.hx
@@ -164,13 +164,7 @@ class HttpRequest extends ufront.web.context.HttpRequest {
 
 		// Finish everything up, check there are no errors, return accordingly.
 		if ( noParts==false ) doEndOfPart();
-		if ( callbackFutures.length>0 ) {
-			return Future.ofMany( callbackFutures ).flatMap( function(_) {
-				return
-					if ( errors.length==0 ) Success(Noise).asFuture()
-					else Failure(Error.withData('Error parsing multipart request data', errors)).asFuture();
-			});
-		}
+		if ( errors.length>0 ) return Failure(Error.withData('Error parsing multipart request data', errors)).asFuture();
 		else return Success(Noise).asFuture();
 	}
 


### PR DESCRIPTION
The code should be functionally equivalent because all sys platforms are synchronous. I'm not 100% sure what is causing the seg fault. I do know that the callbackFutures array is fairly large with a 20MB file. We are talking about 2500+ futures to be resolved.

Anyways, if the code functions the same and doesn't break on large files, I don't see why this shouldn't be merged - even if the root cause is unknown.

Haxe version is 3.4.7
PHP version on server is 5.6.31