### PR TITLE
Fix type wrapping for tink_core 1.18+

### DIFF
--- a/src/ufront/web/ControllerMacros.hx
+++ b/src/ufront/web/ControllerMacros.hx
@@ -805,10 +805,6 @@ class ControllerMacros {
 		else if ( returnType.unify((macro :tink.core.Future<ufront.web.result.ActionResult>).toType()) ) {
 			flags.set(WROutcome);
 		}
-		else if ( returnType.unify((macro :tink.core.Future<StdTypes.Dynamic>).toType()) ) {
-			flags.set(WROutcome);
-			flags.set(WRResultOrError);
-		}
 		else if ( returnType.unify((macro :tink.core.Outcome<ufront.web.result.ActionResult,tink.core.Error>).toType()) ) {
 			flags.set(WRFuture);
 		}
@@ -819,6 +815,10 @@ class ControllerMacros {
 		else if ( returnType.unify((macro :ufront.web.result.ActionResult).toType()) ) {
 			flags.set(WRFuture);
 			flags.set(WROutcome);
+		}
+		else if ( returnType.unify((macro :tink.core.Future<StdTypes.Dynamic>).toType()) ) {
+			flags.set(WROutcome);
+			flags.set(WRResultOrError);
 		}
 		else {
 			// assume return type is `Dynamic`


### PR DESCRIPTION
Since tink_core 1.18, Future has a ofAny @:from cast function, so it unifies with everything. The incorrect type wrappers get generated which was causing an "Invalid call" error with haxelib's page.

Swapping the order of the checks so that ActionResult is prioritised over tink.coreFuture solves this issue.

See: https://github.com/haxetink/tink_core/commit/753c3e8c380dfc2dc9892643524d780df47ff770